### PR TITLE
accessing req object

### DIFF
--- a/lib/passport-http-oauth/strategies/consumer.js
+++ b/lib/passport-http-oauth/strategies/consumer.js
@@ -290,7 +290,7 @@ ConsumerStrategy.prototype.authenticate = function(req) {
 
       if (signatureMethod == 'HMAC-SHA1') {
         var key = consumerSecret + '&';
-        if (tokenSecret) { key += tokenSecret; }
+        if (tokenSecret) { key += utils.encode(tokenSecret); }
         var computedSignature = utils.hmacsha1(key, base);
 
         if (signature !== computedSignature) {

--- a/lib/passport-http-oauth/strategies/token.js
+++ b/lib/passport-http-oauth/strategies/token.js
@@ -222,7 +222,7 @@ TokenStrategy.prototype.authenticate = function(req) {
 
       if (signatureMethod == 'HMAC-SHA1') {
         var key = consumerSecret + '&';
-        if (tokenSecret) { key += tokenSecret; }
+        if (tokenSecret) { key += utils.encode(tokenSecret); }
         var computedSignature = utils.hmacsha1(key, base);
 
         if (signature !== computedSignature) {


### PR DESCRIPTION
Request object is set to the Token Strategy in order to provide additional functionality to the service provider for authenticating the request.
