### PR TITLE
Fix url giving wrong signature base if used with Express app.use()

### DIFF
--- a/lib/passport-http-oauth/strategies/utils.js
+++ b/lib/passport-http-oauth/strategies/utils.js
@@ -26,7 +26,7 @@ exports.originalURL = function(req, defaultHost) {
                ? 'https'
                : 'http'
     , host = defaultHost || headers.host
-    , path = req.originalUrl || '';
+    , path = (typeof req.originalUrl != 'undefined' ? req.originalUrl : req.url) || '';
   return protocol + '://' + host + path;
 };
 


### PR DESCRIPTION
If using Express 4 `app.use()` to mount certain routes paths, the `req.url` will be rewritten to reflect the mounted path. This has the effect of creating a wrong base resulting in an invalid computed signature. I changed it to use `req.originalUrl` since it preserves the original path.

e.g: 
if you use 
<pre><code>app.use('/users', users)</pre></code>
and in your users module you have 
 <pre><code>   /\* GET user by Id. */
    router.get('/:id',
        passport.authenticate('consumer', { session: false }),
        function (req, res) {
            console.log("Authenticated!");
    });</pre></code>

The `req.url` will be set to `http://domain/12345` whereas `req.original` will be `http://domain/users/12345`
