### PR TITLE
utils.originalURL method fixed to support express routers

### DIFF
--- a/lib/passport-http-oauth/strategies/utils.js
+++ b/lib/passport-http-oauth/strategies/utils.js
@@ -26,7 +26,7 @@ exports.originalURL = function(req, defaultHost) {
                ? 'https'
                : 'http'
     , host = defaultHost || headers.host
-    , path = req.url || '';
+    , path = (req.baseUrl || '') + req.url || '';
   return protocol + '://' + host + path;
 };
 


### PR DESCRIPTION
invalid_signature error is thrown when using strategies with express router because of req.url being changed by express and an incorrect signature generated as a result. This one is a more correct solution than in another pull request fixing the same issue (https://github.com/jaredhanson/passport-http-oauth/pull/10) as req.originalUrl used by @tinnou also has all the query string parameters in it, while req.baseUrl + req.url is a correct full path for express requests going through a router.