### PR TITLE
use express's originalUrl when reconstructing request url, fixes #14

### DIFF
--- a/lib/passport-http-oauth/strategies/utils.js
+++ b/lib/passport-http-oauth/strategies/utils.js
@@ -26,7 +26,7 @@ exports.originalURL = function(req, defaultHost) {
                ? 'https'
                : 'http'
     , host = defaultHost || headers.host
-    , path = req.url || '';
+    , path = req.originalUrl || '';
   return protocol + '://' + host + path;
 };
 


### PR DESCRIPTION
Per issue #14, where signature matching fails when a request to authenticate due to `req.url` containing only the last segment of the path