### PR TITLE
Include the mount path when recreating the original URL

### DIFF
--- a/lib/passport-http-oauth/strategies/utils.js
+++ b/lib/passport-http-oauth/strategies/utils.js
@@ -26,8 +26,9 @@ exports.originalURL = function(req, defaultHost) {
                ? 'https'
                : 'http'
     , host = defaultHost || headers.host
+    , base = req.baseUrl || ''
     , path = req.url || '';
-  return protocol + '://' + host + path;
+  return protocol + '://' + host + base + path;
 };
 
 /**


### PR DESCRIPTION
When using consumer strategy with an Express Router on a mount path, validation of the signature will fail because the computed URL doesn't include match the original URL.