### PR TITLE
Add scheme/secureScheme ConsumerStrategy options

### DIFF
--- a/lib/passport-http-oauth/strategies/consumer.js
+++ b/lib/passport-http-oauth/strategies/consumer.js
@@ -122,6 +122,8 @@ function ConsumerStrategy(options, consumer, token, validate) {
   this._consumer = consumer;
   this._token = token;
   this._validate = validate;
+  this._scheme = options.scheme || 'http';
+  this._secureScheme = options.secureScheme || 'https';
   this._host = options.host || null;
   this._realm = options.realm || 'Clients';
   this._ignoreVersion = options.ignoreVersion || false;
@@ -273,7 +275,7 @@ ConsumerStrategy.prototype.authenticate = function(req) {
     }
 
     function validate(tokenSecret, ok) {
-      var url = utils.originalURL(req, self._host)
+      var url = utils.originalURL(req, self._host, self._scheme, self._secureScheme)
         , query = req.query
         , body = req.body;
 

--- a/lib/passport-http-oauth/strategies/utils.js
+++ b/lib/passport-http-oauth/strategies/utils.js
@@ -27,7 +27,10 @@ exports.originalURL = function(req, defaultHost, scheme, secureScheme) {
                : scheme
     , host = defaultHost || headers.host
     , path = req.url || '';
-  return protocol + '://' + host + path;
+  let port = req.headers['x-forwarded-port']
+           ? req.headers['x-forwarded-port']
+           : (req.connection.encrypted ? 443 : 80)
+  return protocol + '://' + host + ':' + port + path;
 };
 
 /**

--- a/lib/passport-http-oauth/strategies/utils.js
+++ b/lib/passport-http-oauth/strategies/utils.js
@@ -22,7 +22,7 @@ var url = require('url')
  */
 exports.originalURL = function(req, defaultHost, scheme, secureScheme) {
   var headers = req.headers
-    , protocol = (req.connection.encrypted || req.headers['x-forwarded-proto'] == secureScheme)
+    , protocol = (req.connection.encrypted || req.headers['x-forwarded-proto'] == 'https')
                ? secureScheme
                : scheme
     , host = defaultHost || headers.host

--- a/lib/passport-http-oauth/strategies/utils.js
+++ b/lib/passport-http-oauth/strategies/utils.js
@@ -20,11 +20,11 @@ var url = require('url')
  * @return {String}
  * @api private
  */
-exports.originalURL = function(req, defaultHost) {
+exports.originalURL = function(req, defaultHost, scheme, secureScheme) {
   var headers = req.headers
-    , protocol = (req.connection.encrypted || req.headers['x-forwarded-proto'] == 'https')
-               ? 'https'
-               : 'http'
+    , protocol = (req.connection.encrypted || req.headers['x-forwarded-proto'] == secureScheme)
+               ? secureScheme
+               : scheme
     , host = defaultHost || headers.host
     , path = req.url || '';
   return protocol + '://' + host + path;


### PR DESCRIPTION
_The sensible defaults are http and https for backwards compatibility_

There are additional protocol schemes which utilize vanilla HTTP/S, but enable additional functionality. The specific example I am submitting this to fix is websockets.

This is a long explanation for a tiny change:

## Why is a change needed?

The scheme string is required to compute the OAuth 1.0a signature. Unfortunately the scheme is not transmitted in HTTP/1.1 requests. The only information known is whether TLS was used to secure the connection (`request.encrypted`). Currently this project assumes `https` if encryption was used, or `http` otherwise. In order to support additional standardized or custom schemes, some changes were needed.

## Why should Websocket support exist in an *HTTP* library!?

Websockets is HTTP as much as HTTPS is HTTP. In the case of HTTPS, the TLS steps happen up front, and is followed by a vanilla HTTP message structure. In the case of Websockets, it's pure HTTP (or HTTPS) up front, and then Websockets afterward. Both of these just build on HTTP, so it's all the same!